### PR TITLE
Fix module not found error in pricutia bot

### DIFF
--- a/bots/pricutia/action-code/0.js
+++ b/bots/pricutia/action-code/0.js
@@ -1,5 +1,5 @@
-import { starSlash } from '../../../src/actions/star-slash.js';
-import { checkStarSlashTrigger } from '../../../src/conditions/trigger-check.js';
+import { starSlash } from '../../src/actions/star-slash.js';
+import { checkStarSlashTrigger } from '../../src/conditions/trigger-check.js';
 
 export async function main(bot) {
     // Periodic check for Star Slash trigger


### PR DESCRIPTION
## Description
This PR fixes a module not found error that was occurring when trying to run the pricutia bot. The error was caused by incorrect import paths in the action code file.

## Changes Made
- Fixed the import paths in  by removing one level of directory traversal ()
- Changed from  to 
- Changed from  to 

## Error Fixed
The error that was occurring was:


The system was looking for the module in the wrong location due to the extra  in the import path.